### PR TITLE
directly calling number by clicking on it

### DIFF
--- a/blockcontact.tpl
+++ b/blockcontact.tpl
@@ -27,7 +27,7 @@
 	<h4 class="title_block">{l s='Contact us' mod='blockcontact'}</h4>
 	<div class="block_content clearfix">
 			<p>{l s='Our support hotline is available 24/7.' mod='blockcontact'}</p>
-			{if $telnumber != ''}<p class="tel"><span class="label">{l s='Phone:' mod='blockcontact'}</span>{$telnumber|escape:'html':'UTF-8'}</p>{/if}
+			{if $telnumber != ''}<p class="tel"><span class="label">{l s='Phone:' mod='blockcontact'}</span><span itemprop="telephone"><a href="tel:{$telnumber|escape:'html':'UTF-8'}">{$telnumber|escape:'html':'UTF-8'}</a></span></p>{/if}
 			{if $email != ''}<a href="mailto:{$email|escape:'html':'UTF-8'}" title="{l s='Contact our expert support team!' mod='blockcontact'}">{l s='Contact our expert support team!' mod='blockcontact'}</a>{/if}
 	</div>
 </div>


### PR DESCRIPTION
Using HTML5-Features on mobile devices, I would suggest to embed the phone number in a "tel"-href. On mobile devices, the user can simply click on the phone number to directly dial it. second point is the "itemprop" attribute to make search engines know about that data.

see http://demosthenes.info/blog/536/Adding-Phone-Numbers-To-Web-Pages-With-HTML5-and-Microdata